### PR TITLE
Added backend recall interface token

### DIFF
--- a/config/hsmConfig
+++ b/config/hsmConfig
@@ -1,6 +1,9 @@
 # storm node serving the file system (if any)
 STORM_BACKEND_NODE="xxx"
 
+# storm recall interface token (mandatory)
+STORM_BACKEND_TOKEN="qqq"
+
 # migrate node list (comma separated)
 MIGRATE_NODE_LIST="xxx,yyy"
 

--- a/scripts/yamssProcessRecall
+++ b/scripts/yamssProcessRecall
@@ -285,7 +285,7 @@ if [ "$recfile"x != "0x" ]; then
        if [ "$RECALL_USE_STORM"x = "1x" ]; then
           for taskid in $($attr -q -g TSMRecT $file 2>/dev/null | tr "," " "); do 
              echo "Setting status=success for file $file and taskid $taskid"
-             $yamssWatchdog -t 60 $curl -s -S -H "Content-Type:text/plain" -X PUT -d "status=0" http://$STORM_BACKEND_NODE:9998/recalltable/task/$taskid 2>/dev/null
+             $yamssWatchdog -t 60 $curl -s -S -H "Content-Type:text/plain" -H "Token:$STORM_BACKEND_TOKEN" -X PUT -d "status=0" http://$STORM_BACKEND_NODE:9998/recalltable/task/$taskid 2>/dev/null
           done
 
           # remove extended attribute with taskids
@@ -340,7 +340,7 @@ if [ "$recfile"x != "0x" ]; then
           if [ "$RECALL_USE_STORM"x = "1x" ]; then
              for taskid in $($attr -q -g TSMRecT $file 2>/dev/null | tr "," " "); do 
                 echo "Setting status=failure for file $file and taskid $taskid"
-                $yamssWatchdog -t 60 $curl -s -S -H "Content-Type:text/plain" -X PUT -d "status=3" http://$STORM_BACKEND_NODE:9998/recalltable/task/$taskid 2>/dev/null
+                $yamssWatchdog -t 60 $curl -s -S -H "Content-Type:text/plain" -H "Token:$STORM_BACKEND_TOKEN" -X PUT -d "status=3" http://$STORM_BACKEND_NODE:9998/recalltable/task/$taskid 2>/dev/null
              done
 
              # remove extended attribute with taskids

--- a/scripts/yamssReorderRecall
+++ b/scripts/yamssReorderRecall
@@ -61,7 +61,7 @@ let numlrec=$numlrec+$numcross
 
 # Files queued in StoRM
 if [ "$RECALL_USE_STORM"x = "1x" ]; then
-  numtakeover=$($yamssWatchdog -t 60 $curl -s -S -X GET http://$STORM_BACKEND_NODE:9998/recalltable/cardinality/tasks/readyTakeOver)
+  numtakeover=$($yamssWatchdog -t 60 $curl -s -S -H "Token:$STORM_BACKEND_TOKEN" -X GET http://$STORM_BACKEND_NODE:9998/recalltable/cardinality/tasks/readyTakeOver)
   # if numtakeover is empty storm is probably offline
   if [ "$numtakeover"x = "x" ]; then
      echo "Error: StoRM recall table service not responding"
@@ -129,7 +129,7 @@ done
 if [ "$RECALL_USE_STORM"x = "1x" -a "$numtakeover"x != "0x" ]; then
 
    # takes over tasks from StoRM recall table
-   $yamssWatchdog -t 60 $curl -s -S -H "Content-Type:text/plain" -X PUT -d first=$RECALL_STORM_DEQUEUE_MAX http://$STORM_BACKEND_NODE:9998/recalltable/tasks 2>/dev/null | tr '#' '\n' | tr "{" " " | tr "}" " " | while read -r myline; do
+   $yamssWatchdog -t 60 $curl -s -S -H "Content-Type:text/plain" -H "Token:$STORM_BACKEND_TOKEN" -X PUT -d first=$RECALL_STORM_DEQUEUE_MAX http://$STORM_BACKEND_NODE:9998/recalltable/tasks 2>/dev/null | tr '#' '\n' | tr "{" " " | tr "}" " " | while read -r myline; do
      taskid=$(echo "$myline"|awk '{print $1}')
      fname=$(echo "$myline"|awk '{print $5}')
      cattr=$($attr -q -g TSMRecT $fname 2>/dev/null)


### PR DESCRIPTION
From StoRM Backend v1.11.12 that is going to be released, a token has been added to the recall interface.
This PR adds to gemss the configuration variable STORM_BACKEND_TOKEN that must be set to the same value assigned to the StoRM Backend STORM_BE_XMLRPC_TOKEN YAIM variable value.
Read [sys-admin guide](http://italiangrid.github.io/storm/documentation/sysadmin-guide/1.11.12/#generalyaimvars).

This token has been introduced because we want to improve security after the fix/introduction of the POST of a new recall task through the recall interface.